### PR TITLE
package more than parent charts

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -10,7 +10,7 @@ docker-build: ## Build the top level Dockerfile using the directory or $IMAGE_NA
 
 .PHONY: docker-tag
 docker-tag: ## Tag the docker image using the tag script.
-	tag $(IMAGE_NAME) $(DOCKER_REPO)/$(IMAGE_NAME) --no-latest
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO)/$(IMAGE_NAME)
 
 .PHONY: docker-publish
 docker-publish: docker-tag ## Publish the image and tags to a repository.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,10 @@ verifyParameters
 
 if [[ -f "$TARGET/Chart.yaml" ]]; then
 	chart=$(basename "$TARGET")
-  # If we are packaging the Grey Matter chart, we need to get the requirements from Nexus
-  if [[ "$chart" == "greymatter" ]]; then
+  # If we are packaging a parent chart, we need to get the requirements from Nexus
+  if [[ "$chart" == "greymatter" ]] || [[ "$chart" == "fabric" ]] || [[ "$chart" == "data" ]] || [[ "$chart" == "sense" ]] ; then
     helm repo add decipher "$INPUT_NEXUS_URL" --username "$INPUT_NEXUS_USER" --password "$INPUT_NEXUS_PASS"
-    helm dependency update greymatter
+    helm dependency update "$TARGET"
   fi
 	echo "Packaging $chart from $TARGET"
 	helm package "$TARGET"


### PR DESCRIPTION
This pr updates the entrypoint script to include multiple parent directories to allow packaging for the new helm charts (greymatter -> fabric, sense, data) as per [helm charts pr503](https://github.com/DecipherNow/helm-charts/pull/503)

