### PR TITLE
clean charts directory before packaging

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -6,12 +6,20 @@ docker-lint: ## Run Dockerfile Lint on all dockerfiles.
 
 .PHONY: docker-build
 docker-build: ## Build the top level Dockerfile using the directory or $IMAGE_NAME as the name.
-	docker build --build-arg HELM_VERSION=$(HELM_VERSION) -t $(IMAGE_NAME) .
+	docker build --build-arg HELM_VERSION=$(HELM_VERSION) -t $(IMAGE_NAME) . --no-cache
 
 .PHONY: docker-tag
 docker-tag: ## Tag the docker image using the tag script.
 	docker tag $(IMAGE_NAME) $(DOCKER_REPO)/helm-packager:$(HELM_VERSION)
 
+.PHONY: docker-tag-dev
+docker-tag-dev: ## Tag the docker image using the tag script.
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO)/helm-packager:$(HELM_VERSION)-dev
+
 .PHONY: docker-publish
 docker-publish: docker-tag ## Publish the image and tags to a repository.
 	docker push $(DOCKER_REPO)/helm-packager:$(HELM_VERSION)
+
+.PHONY: docker-publish-dev
+docker-publish-dev: docker-tag ## Publish the image and tags to a repository.
+	docker push $(DOCKER_REPO)/helm-packager:$(HELM_VERSION)-dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,12 +32,13 @@ if [[ -f "$TARGET/Chart.yaml" ]]; then
   # If we are packaging a parent chart, we need to get the requirements from Nexus
   if [[ "$chart" == "greymatter" ]] || [[ "$chart" == "fabric" ]] || [[ "$chart" == "data" ]] || [[ "$chart" == "sense" ]] || [[ "$chart" == "spire" ]]; then
     helm repo add decipher "$INPUT_NEXUS_URL" --username "$INPUT_NEXUS_USER" --password "$INPUT_NEXUS_PASS"
+    rm -rf $TARGET/charts
     helm dependency update "$TARGET"
   fi
 	echo "Packaging $chart from $TARGET"
 	helm package "$TARGET"
   echo "Publishing $chart to Nexus"
-  pkg=$(ls ./*.tgz)
+  pkg=$(ls $chart*.tgz)
   curl -u "$INPUT_NEXUS_USER":"$INPUT_NEXUS_PASS" "$INPUT_NEXUS_URL" -T "$pkg"
 	exit $?
 else


### PR DESCRIPTION

clean charts directory before packaging (needed for fabric where we reuse the helm-chart but with different Chart.yaml aka jwt-gov)
adds `-dev` docker make targets